### PR TITLE
SC-12764 Fix travis CI build to use Ubuntu 22 & JDK17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
+language: java
+
 sudo: false
 install: true
+
+dist: jammy
+
+jdk: openjdk17
 
 addons:
   sonarcloud:
@@ -8,14 +14,14 @@ addons:
       secure: "RfH/EbIMdlyILuURtxvvKQ5HYF+GgHWp8RWeBPs17XFcRpIroAlx4/UJzzcOMfvGfk6ce1lrWT1WQyhW5g7fRL0SGKmq2hsDG3q00gfyTciVyGnF6XKNy4VhWA+EAuN6qU7U/dcWf8ttSlO2fxAQNifpn6PhAmjF3CLLUHkCfEbz01HOoaA/BtFJReWtfmLDWLcGgEz3lzWtiobujYwE86Fz6Ch2JjYIjqFkPyffUaCOXWjPkSOTOO4o+TspX9GlgT9aj8WR0xfECvpnKr6s3Gx/zX/dbulV3R2JfUSHelByi72V4e69PzCx0per4wSc6eZyUaVYo2RSaGC38eypXQwN7MZOX26HV+STTeaVNMHXveoOuFHvlop/aXKkxcDv4MGaIq7WwniJoAWwziBweZTnVtJbn+FvEBLCfpuSxMYAW3SKR63PN56oMisSdZEyjnsRXgasj15sUgHVBpEqVGQNXs39Xqi3TpRxoCeZaWKraZC1ZqcGL0OYxVD4l+YmNabXIMG9+JdtyWRjtytDZXMRa4Uxq/NPVR9gtOBbiGbliiedC5uFhR8gI2PqWNEVxlp60C1Daryi4nmW6c797z+VLSu3p7a3QFKDfUDDYxvMoN8DTl4A1x6BWopFUHFiGu/qXvfSy9uBUgt0McQW7YO9lLlUHzFDMJWbP0D+3Cs="
 
 script:
-  - ./gradlew sonarqube
+  - ./gradlew build sonar
 
 cache:
   directories:
-    - '$HOME/.m2/repository'
-    - '$HOME/.sonar/cache'
-    - '$HOME/.gradle'
-    - '.gradle'
+    - "$HOME/.m2/repository"
+    - "$HOME/.sonar/cache"
+    - "$HOME/.gradle"
+    - ".gradle"
 
 # Don't copy the following part if your usnig this project as a starting point of yours
 notifications:

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.sonarqube" version "2.7.1"
+    id "org.sonarqube" version "5.0.0.4638"
 }
 
 apply plugin: 'java'
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
 }
 
 sonarqube {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The build is currently broken because java 11 is used to scan this project.

This PR:
- Bumps the distribution used in CI from `xenial` to `jammy` (which includes JDK17, and switches java version to it).
- Adds the build step to gradlew before running the Sonar analysis
- Renames `sonarqube` gradle task to `sonar`
- Bumps junit dep version to `4.13.1`
- Fix gradle syntax & bump its version to `7.5.1`