### PR TITLE
SC-35440 scripted update of SonarSource SA to SonarSource Sàrl

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 sq-com_example_java-gradle-travis
-Copyright (C) 2016-2017 SonarSource SA
+Copyright (C) 2016-2017 SonarSource Sàrl
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 sq-com_example_java-gradle-travis
-Copyright (C) 2016-2017 SonarSource Sàrl
+Copyright (C) 2016-2025 SonarSource Sàrl
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at


### PR DESCRIPTION
Automated update of license headers to change 'SonarSource SA' to 'SonarSource Sàrl' across all text files.

This change was made using the auto_license_replacement.py.py script.